### PR TITLE
remove numpy from callbacks

### DIFF
--- a/src/lightning/pytorch/callbacks/early_stopping.py
+++ b/src/lightning/pytorch/callbacks/early_stopping.py
@@ -21,7 +21,6 @@ Monitor a metric and stop training when it stops improving.
 import logging
 from typing import Any, Callable, Dict, Optional, Tuple
 
-import numpy as np
 import torch
 from torch import Tensor
 
@@ -123,7 +122,7 @@ class EarlyStopping(Callback):
             raise MisconfigurationException(f"`mode` can be {', '.join(self.mode_dict.keys())}, got {self.mode}")
 
         self.min_delta *= 1 if self.monitor_op == torch.gt else -1
-        torch_inf = torch.tensor(np.Inf)
+        torch_inf = torch.tensor(torch.inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
 
     @property

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -27,7 +27,6 @@ from datetime import timedelta
 from typing import Any, Dict, Optional, Set
 from weakref import proxy
 
-import numpy as np
 import torch
 import yaml
 from torch import Tensor
@@ -442,7 +441,7 @@ class ModelCheckpoint(Checkpoint):
         self.filename = filename
 
     def __init_monitor_mode(self, mode: str) -> None:
-        torch_inf = torch.tensor(np.Inf)
+        torch_inf = torch.tensor(torch.inf)
         mode_dict = {"min": (torch_inf, "min"), "max": (-torch_inf, "max")}
 
         if mode not in mode_dict:


### PR DESCRIPTION
As numpy update to 2.0.0, no such np.Inf usage any more.
